### PR TITLE
feat(domain): add seeded direction selection for render_text_video

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
     --duration-seconds <FLOAT> \
     [--fps <INT>] \
     [--background <transparent|#RRGGBB>] \
-    [--fonts-dir <PATH>]
+    [--fonts-dir <PATH>] \
+    [--direction-seed <INT>] \
+    [--emit-directions]
 ```
 
 **Notes**
@@ -217,6 +219,8 @@ Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
 * Input text must be valid UTF-8 and is split on whitespace.
 * `.srt` input files are parsed as subtitle windows; words render only inside each time range.
 * `--fonts-dir` should contain .ttf/.otf fonts (bold variants recommended).
+* `--direction-seed` makes direction selection deterministic for a given seed.
+* `--emit-directions` prints a JSON direction list and exits without rendering.
 * Output is always a `.mov` file; default name is `video.mov`.
 
 ---

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -13,7 +13,7 @@ Each issue is formatted as `- [ ] [<ID>-<number>]`. When resolved it becomes -` 
 
 - [x] [I100] Allow [text](../render_text_video.py) file to parse srt files with subtitles and timing, and distribute the words only through the timwindow allowed in subtitles. See example in [text](../data/inputs/captions.srt). Resolved with SRT parsing, timing-aware scheduling, and integration tests.
 
-- [ ] [I101] Add randomness to text genration, e.g. do not deterministically circle through the directions of movement of the words but have randon choice of how the words will move (only using predefined four directions of movement for now)
+- [x] [I101] Add randomness to text genration, e.g. do not deterministically circle through the directions of movement of the words but have randon choice of how the words will move (only using predefined four directions of movement for now). Resolved with seeded random direction selection and integration tests.
 
 ## BugFixes (300–399)
 


### PR DESCRIPTION
- add deterministic RNG-based direction plan and emit option

- adapt CLI to accept direction seed and emit JSON directions

- add integration test for deterministic direction output

- wrap outputs with stable codes via existing error handling

- CI: mypy --strict domain service; pytest -q
