### PR TITLE
feat(domain): introduce CI workflow smart constructor; move validation to edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Run CI
+        run: make ci

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -58,3 +58,9 @@ proceed
 ## Tooling Baseline (I100)
 - `make test` failed before changes because SRT window validation is not implemented yet.
 - `make lint` failed before changes because `domain/` and `service/` packages do not exist yet.
+
+## Maintenance Additions (400–499)
+- [x] [M403] Add GitHub Actions CI to run `make ci` with uv and ffmpeg. Resolved with new workflow and local `make ci`.
+
+## Issue Context Addendum (M401)
+- [M403] Priority: medium. Goal: add GitHub Actions CI workflow running `make ci`. Dependencies: ubuntu runner with ffmpeg, uv install action. Docs: `README.md` optional. Plan: add workflow, run `make ci`, mark issue resolved. Deliverable: `.github/workflows/ci.yml` running on push/PR.


### PR DESCRIPTION
- add CI workflow with invariants: ubuntu-latest, uv setup, ffmpeg install, make ci

- adapt handlers/adapters to construct at edges (n/a for workflow-only change)

- remove interior defensive checks (validated once at boundary) (n/a)

- wrap errors with operation+subject+stable code (n/a)

- CI: make ci
