### PR TITLE
Default punctuation removal with keep override

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
     [--fonts-dir <PATH>] \
     [--direction-seed <INT>] \
     [--remove-punctuation] \
+    [--keep-punctuation] \
     [--subtitle-renderer <motion|criss_cross|rsvp_orp>] \
     [--font-min <INT>] \
     [--font-max <INT>] \
@@ -226,7 +227,9 @@ Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
 * Provide either `--background-image` or `--width`/`--height` (image derives dimensions).
 * `--fonts-dir` should contain .ttf/.otf fonts (bold variants recommended).
 * `--direction-seed` makes direction selection deterministic for a given seed.
-* `--remove-punctuation` strips punctuation from words before rendering.
+* Punctuation is stripped by default; use `--keep-punctuation` to preserve punctuation.
+* `--remove-punctuation` is accepted for compatibility but matches the default behavior.
+* RSVP punctuation pauses only apply when punctuation is preserved.
 * `--subtitle-renderer criss_cross` explicitly selects the randomized motion renderer (default behavior).
 * `--subtitle-renderer rsvp_orp` enables RSVP/ORP subtitles from SRT input (single word at a time with ORP anchoring).
 * RSVP mode requires SRT timing and does not use motion directions or per-word random sizing.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -152,3 +152,5 @@ proceed
 - [x] [I107] Resolved criss_cross renderer selection with optional font-min/font-max bounds and integration tests.
 - [ ] [I108] Make punctuation removal the default across renderers with an explicit keep-punctuation override.
 - [x] [I108] Resolved default punctuation removal with keep-punctuation override across renderers.
+- [ ] [B314] Allow RSVP windows longer than max per-word timing by leaving idle slack instead of failing.
+- [x] [B314] Resolved RSVP long-window handling by capping per-word timing and allowing trailing idle frames, with integration coverage.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -150,3 +150,5 @@ proceed
 - [x] [F100] Resolved RSVP ORP renderer with SRT-only mode, ORP anchoring, weighted timing + punctuation pauses, and render-verified integration tests.
 - [ ] [I107] Allow optional font size bounds for criss_cross renderer via --font-min/--font-max and explicit --subtitle-renderer criss_cross selection.
 - [x] [I107] Resolved criss_cross renderer selection with optional font-min/font-max bounds and integration tests.
+- [ ] [I108] Make punctuation removal the default across renderers with an explicit keep-punctuation override.
+- [x] [I108] Resolved default punctuation removal with keep-punctuation override across renderers.

--- a/render_text_video.py
+++ b/render_text_video.py
@@ -933,7 +933,7 @@ def build_subtitle_windows(
                 INVALID_CONFIG_CODE,
                 "rsvp_orp requires SRT input",
             )
-        return parse_srt(text_value, remove_punctuation=False)
+        return parse_srt(text_value, remove_punctuation)
 
     if is_srt_extension or is_srt_content:
         return parse_srt(text_value, remove_punctuation)
@@ -1231,13 +1231,16 @@ def parse_args(argv: Sequence[str]) -> RenderRequest:
     parser.add_argument("--fonts-dir", default="fonts")
     parser.add_argument("--direction-seed", type=int, default=None)
     parser.add_argument("--emit-directions", action="store_true")
-    parser.add_argument("--remove-punctuation", action="store_true")
+    punctuation_group = parser.add_mutually_exclusive_group()
+    punctuation_group.add_argument("--remove-punctuation", action="store_true")
+    punctuation_group.add_argument("--keep-punctuation", action="store_true")
     parser.add_argument("--subtitle-renderer", default="motion")
     parser.add_argument("--font-min", type=int, default=None)
     parser.add_argument("--font-max", type=int, default=None)
 
     parsed = parser.parse_args(argv)
     subtitle_renderer = parse_subtitle_renderer(parsed.subtitle_renderer)
+    remove_punctuation = not parsed.keep_punctuation
     background_rgba = parse_hex_color_to_rgba(parsed.background)
     background_image = None
 
@@ -1249,11 +1252,6 @@ def parse_args(argv: Sequence[str]) -> RenderRequest:
         if parsed.emit_directions:
             raise RenderValidationError(
                 INVALID_CONFIG_CODE, "emit-directions is not supported for rsvp_orp"
-            )
-        if parsed.remove_punctuation:
-            raise RenderValidationError(
-                INVALID_CONFIG_CODE,
-                "remove-punctuation is not supported for rsvp_orp",
             )
         if parsed.font_min is not None or parsed.font_max is not None:
             raise RenderValidationError(
@@ -1313,7 +1311,7 @@ def parse_args(argv: Sequence[str]) -> RenderRequest:
         config=config,
         direction_seed=parsed.direction_seed,
         emit_directions=parsed.emit_directions,
-        remove_punctuation=parsed.remove_punctuation,
+        remove_punctuation=remove_punctuation,
         background_image=background_image,
     )
 

--- a/service/render_plan.py
+++ b/service/render_plan.py
@@ -280,8 +280,16 @@ def build_rsvp_render_plan(
                 INVALID_WINDOW_CODE, "subtitle window too short for RSVP pauses"
             )
 
+        min_total = min_frames * word_count
+        max_total = max_frames * word_count
+        if available_frames < min_total:
+            raise RenderValidationError(
+                INVALID_WINDOW_CODE, "subtitle window too short for RSVP timing"
+            )
+        target_frames = min(available_frames, max_total)
+
         base_frames = allocate_weighted_frames(
-            weights, available_frames, min_frames, max_frames
+            weights, target_frames, min_frames, max_frames
         )
         per_word_frames = [
             base + (pause_frames if flagged else 0)
@@ -301,9 +309,9 @@ def build_rsvp_render_plan(
             cursor_frame += frame_count
             words.append(word)
 
-        if cursor_frame != window_end_frame:
+        if cursor_frame > window_end_frame:
             raise RenderValidationError(
-                INVALID_WINDOW_CODE, "subtitle window timing mismatch"
+                INVALID_WINDOW_CODE, "subtitle window timing overflow"
             )
 
         token_offset += word_count

--- a/tests/test_render_text_video.py
+++ b/tests/test_render_text_video.py
@@ -771,7 +771,7 @@ def test_rsvp_orp_anchor_is_stable(tmp_path: Path) -> None:
             width=width,
             height=height,
         )
-        args.extend(["--subtitle-renderer", "rsvp_orp"])
+        args.extend(["--subtitle-renderer", "rsvp_orp", "--keep-punctuation"])
         result = run_render_text_video(args, repo_root)
         assert result.returncode == 0
         return output_path
@@ -903,7 +903,7 @@ def test_rsvp_orp_punctuation_pause_extends_word(tmp_path: Path) -> None:
             width=width,
             height=height,
         )
-        args.extend(["--subtitle-renderer", "rsvp_orp"])
+        args.extend(["--subtitle-renderer", "rsvp_orp", "--keep-punctuation"])
         result = run_render_text_video(args, repo_root)
         assert result.returncode == 0
         return output_path
@@ -1085,9 +1085,9 @@ def test_remove_punctuation(tmp_path: Path) -> None:
         fps=fps,
     )
 
-    args_strip = base_args + ["--remove-punctuation", "--direction-seed", seed]
-    stripped = run_render_text_video(args_strip, repo_root)
-    assert stripped.returncode == 0
+    args_default = base_args + ["--direction-seed", seed]
+    default_result = run_render_text_video(args_default, repo_root)
+    assert default_result.returncode == 0
 
     output_path_keep = tmp_path / "out-keep.mov"
     args_keep = build_common_args(
@@ -1098,14 +1098,14 @@ def test_remove_punctuation(tmp_path: Path) -> None:
         duration_seconds=duration_seconds,
         fps=fps,
     )
-    args_keep.extend(["--direction-seed", seed])
+    args_keep.extend(["--direction-seed", seed, "--keep-punctuation"])
     kept = run_render_text_video(args_keep, repo_root)
     assert kept.returncode == 0
 
     time_seconds = float(duration_seconds) / 2.0
-    stripped_frame = extract_raw_frame(output_path, time_seconds)
+    default_frame = extract_raw_frame(output_path, time_seconds)
     kept_frame = extract_raw_frame(output_path_keep, time_seconds)
-    assert stripped_frame != kept_frame
+    assert default_frame != kept_frame
 
 
 def test_background_image_derives_dimensions(tmp_path: Path) -> None:

--- a/tests/test_render_text_video.py
+++ b/tests/test_render_text_video.py
@@ -964,6 +964,51 @@ def test_rsvp_orp_punctuation_pause_extends_word(tmp_path: Path) -> None:
     assert counts[words[0]] + counts[words[1]] == total_frames
 
 
+def test_rsvp_orp_allows_long_window(tmp_path: Path) -> None:
+    """Allow RSVP windows longer than max per-word timing."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "render_text_video.py"
+    fonts_dir = repo_root / "assets" / "fonts"
+
+    width = 240
+    height = 180
+    duration_seconds = "3.0"
+    fps = "10"
+    input_text = "alpha beta"
+
+    srt_content = "1\n00:00:00,000 --> 00:00:03,000\nalpha beta\n"
+    input_path = tmp_path / "long.srt"
+    input_path.write_text(srt_content, encoding="utf-8")
+
+    output_path = tmp_path / "out.mov"
+    args = build_common_args(
+        script_path=script_path,
+        input_path=input_path,
+        output_path=output_path,
+        fonts_dir=fonts_dir,
+        duration_seconds=duration_seconds,
+        fps=fps,
+        width=width,
+        height=height,
+    )
+    args.extend(["--subtitle-renderer", "rsvp_orp"])
+    result = run_render_text_video(args, repo_root)
+    assert result.returncode == 0
+
+    total_frames = int(round(float(duration_seconds) * float(fps)))
+    alpha_frames = 0
+    for frame_index in range(total_frames):
+        frame_bytes = extract_raw_frame(output_path, frame_index / float(fps))
+        if not frame_has_expected_size(frame_bytes, width, height):
+            continue
+        if frame_has_alpha(frame_bytes, width, height):
+            alpha_frames += 1
+
+    max_frames = int(math.floor(0.700 * float(fps)))
+    expected_frames = max_frames * len(input_text.split())
+    assert alpha_frames == expected_frames
+
+
 def test_font_bounds_require_criss_cross_renderer(tmp_path: Path) -> None:
     """Reject font bounds unless criss_cross renderer is selected."""
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- make punctuation removal the default for all renderers
- add --keep-punctuation override and update RSVP handling/tests
- update docs and issue log

## Testing
- make lint
- make test
- make ci
