### PR TITLE
Fix RSVP long-window timing

### DIFF
--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -152,3 +152,5 @@ proceed
 - [x] [I107] Resolved criss_cross renderer selection with optional font-min/font-max bounds and integration tests.
 - [ ] [I108] Make punctuation removal the default across renderers with an explicit keep-punctuation override.
 - [x] [I108] Resolved default punctuation removal with keep-punctuation override across renderers.
+- [ ] [B314] Allow RSVP windows longer than max per-word timing by leaving idle slack instead of failing.
+- [x] [B314] Resolved RSVP long-window handling by capping per-word timing and allowing trailing idle frames, with integration coverage.

--- a/service/render_plan.py
+++ b/service/render_plan.py
@@ -280,8 +280,16 @@ def build_rsvp_render_plan(
                 INVALID_WINDOW_CODE, "subtitle window too short for RSVP pauses"
             )
 
+        min_total = min_frames * word_count
+        max_total = max_frames * word_count
+        if available_frames < min_total:
+            raise RenderValidationError(
+                INVALID_WINDOW_CODE, "subtitle window too short for RSVP timing"
+            )
+        target_frames = min(available_frames, max_total)
+
         base_frames = allocate_weighted_frames(
-            weights, available_frames, min_frames, max_frames
+            weights, target_frames, min_frames, max_frames
         )
         per_word_frames = [
             base + (pause_frames if flagged else 0)
@@ -301,9 +309,9 @@ def build_rsvp_render_plan(
             cursor_frame += frame_count
             words.append(word)
 
-        if cursor_frame != window_end_frame:
+        if cursor_frame > window_end_frame:
             raise RenderValidationError(
-                INVALID_WINDOW_CODE, "subtitle window timing mismatch"
+                INVALID_WINDOW_CODE, "subtitle window timing overflow"
             )
 
         token_offset += word_count

--- a/tests/test_render_text_video.py
+++ b/tests/test_render_text_video.py
@@ -964,6 +964,51 @@ def test_rsvp_orp_punctuation_pause_extends_word(tmp_path: Path) -> None:
     assert counts[words[0]] + counts[words[1]] == total_frames
 
 
+def test_rsvp_orp_allows_long_window(tmp_path: Path) -> None:
+    """Allow RSVP windows longer than max per-word timing."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "render_text_video.py"
+    fonts_dir = repo_root / "assets" / "fonts"
+
+    width = 240
+    height = 180
+    duration_seconds = "3.0"
+    fps = "10"
+    input_text = "alpha beta"
+
+    srt_content = "1\n00:00:00,000 --> 00:00:03,000\nalpha beta\n"
+    input_path = tmp_path / "long.srt"
+    input_path.write_text(srt_content, encoding="utf-8")
+
+    output_path = tmp_path / "out.mov"
+    args = build_common_args(
+        script_path=script_path,
+        input_path=input_path,
+        output_path=output_path,
+        fonts_dir=fonts_dir,
+        duration_seconds=duration_seconds,
+        fps=fps,
+        width=width,
+        height=height,
+    )
+    args.extend(["--subtitle-renderer", "rsvp_orp"])
+    result = run_render_text_video(args, repo_root)
+    assert result.returncode == 0
+
+    total_frames = int(round(float(duration_seconds) * float(fps)))
+    alpha_frames = 0
+    for frame_index in range(total_frames):
+        frame_bytes = extract_raw_frame(output_path, frame_index / float(fps))
+        if not frame_has_expected_size(frame_bytes, width, height):
+            continue
+        if frame_has_alpha(frame_bytes, width, height):
+            alpha_frames += 1
+
+    max_frames = int(math.floor(0.700 * float(fps)))
+    expected_frames = max_frames * len(input_text.split())
+    assert alpha_frames == expected_frames
+
+
 def test_font_bounds_require_criss_cross_renderer(tmp_path: Path) -> None:
     """Reject font bounds unless criss_cross renderer is selected."""
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- allow long RSVP windows by capping per-word timing and leaving idle slack
- add integration test to cover long RSVP cues
- update issue log

## Testing
- make lint
- make test
- make ci
