### PR TITLE
Reduce alpha MOV size with adaptive ProRes settings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@ using inline PEP 723 metadata.
 
 ## External dependencies
 - Python 3.11+ and `uv` on PATH.
-- `ffmpeg` with `prores_ks` (alpha_bits) and `yuva444p10le` support for `render_text_video.py`.
+- `ffmpeg` with `prores_ks` (alpha_bits), `yuva444p10le`, and `libx264` support for `render_text_video.py`.
 - Fonts (TTF/OTF) provided via `--fonts-dir` for `render_text_video.py`.
 
 ## Common flow

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,7 +28,7 @@ using inline PEP 723 metadata.
 
 ## External dependencies
 - Python 3.11+ and `uv` on PATH.
-- `ffmpeg` with `prores_ks` and `yuva444p10le` support for `render_text_video.py`.
+- `ffmpeg` with `prores_ks` (alpha_bits) and `yuva444p10le` support for `render_text_video.py`.
 - Fonts (TTF/OTF) provided via `--fonts-dir` for `render_text_video.py`.
 
 ## Common flow

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test lint ci
 
 test:
-	uv run --no-project --with pytest -- python -m pytest -q
+	uv run --no-project --with pytest --with pillow -- python -m pytest -q
 
 lint:
 	uv run --no-project --with mypy -- mypy --strict domain service

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ HEIF/HEIC is supported via `pillow-heif`.
 
 Render animated word-by-word text into a transparent ProRes 4444 MOV.
 
-Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
+Requires `ffmpeg` with `prores_ks` (alpha_bits) and `yuva444p10le` support.
 
 **Usage:**
 
@@ -235,6 +235,7 @@ Requires `ffmpeg` with `prores_ks` and `yuva444p10le` support.
 * RSVP mode requires SRT timing and does not use motion directions or per-word random sizing.
 * `--font-min`/`--font-max` constrain the randomized font size range for `criss_cross`.
 * `--background` applies only when no background image is used.
+* ProRes output uses adaptive quantization plus 8-bit alpha to reduce file sizes on large frames.
 * Font sizes are randomized per word within a dynamic range derived from frame size (large enough to overflow the frame).
 * Letters render in per-letter bands aligned with the motion axis; band offsets are centered and spaced by glyph sizes with tracking, reversed for L2R/T2B so the first letter leads the motion, and vertical directions also add staggered offsets.
 * `--emit-directions` prints JSON with `directions`, `font_sizes`, `words`, `letter_offsets`, `letter_bands`, and `letter_band_sizes` (band offsets centered on the motion axis), then exits without rendering.

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ HEIF/HEIC is supported via `pillow-heif`.
 
 ### `render_text_video.py`
 
-Render animated word-by-word text into a transparent ProRes 4444 MOV.
+Render animated word-by-word text into a MOV (transparent output uses ProRes 4444).
 
-Requires `ffmpeg` with `prores_ks` (alpha_bits) and `yuva444p10le` support.
+Requires `ffmpeg` with `prores_ks` (alpha_bits), `yuva444p10le`, and `libx264` support.
 
 **Usage:**
 
@@ -236,6 +236,7 @@ Requires `ffmpeg` with `prores_ks` (alpha_bits) and `yuva444p10le` support.
 * `--font-min`/`--font-max` constrain the randomized font size range for `criss_cross`.
 * `--background` applies only when no background image is used.
 * ProRes output uses adaptive quantization plus 8-bit alpha to reduce file sizes on large frames.
+* Transparent output (no background image and `--background transparent`) uses ProRes 4444 with alpha; any opaque background uses H.264 without alpha for better compression.
 * Font sizes are randomized per word within a dynamic range derived from frame size (large enough to overflow the frame).
 * Letters render in per-letter bands aligned with the motion axis; band offsets are centered and spaced by glyph sizes with tracking, reversed for L2R/T2B so the first letter leads the motion, and vertical directions also add staggered offsets.
 * `--emit-directions` prints JSON with `directions`, `font_sizes`, `words`, `letter_offsets`, `letter_bands`, and `letter_band_sizes` (band offsets centered on the motion axis), then exits without rendering.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Requires `ffmpeg` with `prores_ks` (alpha_bits), `yuva444p10le`, and `libx264` s
 * `--subtitle-renderer criss_cross` explicitly selects the randomized motion renderer (default behavior).
 * `--subtitle-renderer rsvp_orp` enables RSVP/ORP subtitles from SRT input (single word at a time with ORP anchoring).
 * RSVP mode requires SRT timing and does not use motion directions or per-word random sizing.
-* `--font-min`/`--font-max` constrain the randomized font size range for `criss_cross`.
+* `--font-min`/`--font-max` constrain the randomized font size range for `criss_cross`; if only one bound is provided, the other bound is clamped to it.
 * `--background` applies only when no background image is used.
 * ProRes output uses adaptive quantization plus 8-bit alpha to reduce file sizes on large frames.
 * Transparent output (no background image and `--background transparent`) uses ProRes 4444 with alpha; any opaque background uses H.264 without alpha for better compression.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Requires `ffmpeg` with `prores_ks` (alpha_bits), `yuva444p10le`, and `libx264` s
 * `--background` applies only when no background image is used.
 * ProRes output uses adaptive quantization plus 8-bit alpha to reduce file sizes on large frames.
 * Transparent output (no background image and `--background transparent`) uses ProRes 4444 with alpha; any opaque background uses H.264 without alpha for better compression.
+* Opaque output uses yuv420p and requires even frame dimensions (odd sizes are rejected).
 * Font sizes are randomized per word within a dynamic range derived from frame size (large enough to overflow the frame).
 * Letters render in per-letter bands aligned with the motion axis; band offsets are centered and spaced by glyph sizes with tracking, reversed for L2R/T2B so the first letter leads the motion, and vertical directions also add staggered offsets.
 * `--emit-directions` prints JSON with `directions`, `font_sizes`, `words`, `letter_offsets`, `letter_bands`, and `letter_band_sizes` (band offsets centered on the motion axis), then exits without rendering.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -168,3 +168,5 @@ proceed
 - [x] [B318] Resolved baseline alignment by anchoring per-letter bboxes to the baseline and positioning horizontal letters using the baseline in render_text_video.
 - [ ] [B319] Add integration coverage for mixed-script baseline alignment (Latin + Cyrillic).
 - [x] [B319] Resolved baseline alignment coverage with mixed-script render verification and test dependency updates.
+- [ ] [B320] Validate even dimensions for opaque H.264 output to avoid runtime ffmpeg failures.
+- [x] [B320] Resolved even-dimension validation with CLI checks and integration tests for odd sizes.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -166,3 +166,5 @@ proceed
 - [x] [I110] Resolved font-max clamping by aligning the computed minimum to the provided max and adding render_text_video integration coverage.
 - [ ] [B318] Align horizontal letter rendering to a shared baseline to avoid wacky typography.
 - [x] [B318] Resolved baseline alignment by anchoring per-letter bboxes to the baseline and positioning horizontal letters using the baseline in render_text_video.
+- [ ] [B319] Add integration coverage for mixed-script baseline alignment (Latin + Cyrillic).
+- [x] [B319] Resolved baseline alignment coverage with mixed-script render verification and test dependency updates.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -164,3 +164,5 @@ proceed
 - [x] [I109] Resolved opaque output by switching to H.264 (libx264) when alpha is not needed and validating the codec in integration tests.
 - [ ] [I110] Allow `--font-max` alone to clamp the default minimum size for criss_cross rendering.
 - [x] [I110] Resolved font-max clamping by aligning the computed minimum to the provided max and adding render_text_video integration coverage.
+- [ ] [B318] Align horizontal letter rendering to a shared baseline to avoid wacky typography.
+- [x] [B318] Resolved baseline alignment by anchoring per-letter bboxes to the baseline and positioning horizontal letters using the baseline in render_text_video.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -162,3 +162,5 @@ proceed
 - [x] [B317] Resolved alpha MOV size by scaling ProRes quantization with frame size and using 8-bit alpha, plus ffmpeg capability checks.
 - [ ] [I109] Use non-alpha encoding when a background image or solid color is provided; reserve alpha output for transparent backgrounds.
 - [x] [I109] Resolved opaque output by switching to H.264 (libx264) when alpha is not needed and validating the codec in integration tests.
+- [ ] [I110] Allow `--font-max` alone to clamp the default minimum size for criss_cross rendering.
+- [x] [I110] Resolved font-max clamping by aligning the computed minimum to the provided max and adding render_text_video integration coverage.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -158,3 +158,5 @@ proceed
 - [x] [B315] Resolved CI font failures by tracking assets/fonts and updating .gitignore.
 - [ ] [B316] Replace asset font tracking with test fixtures to keep assets uncommitted and CI green.
 - [x] [B316] Resolved CI font fixture handling by moving fonts to tests/fixtures and restoring assets ignore.
+- [ ] [B317] Reduce alpha MOV size further for long background renders (20GB/100s) with a smaller alpha payload.
+- [x] [B317] Resolved alpha MOV size by scaling ProRes quantization with frame size and using 8-bit alpha, plus ffmpeg capability checks.

--- a/issues.md/ISSUES.md
+++ b/issues.md/ISSUES.md
@@ -160,3 +160,5 @@ proceed
 - [x] [B316] Resolved CI font fixture handling by moving fonts to tests/fixtures and restoring assets ignore.
 - [ ] [B317] Reduce alpha MOV size further for long background renders (20GB/100s) with a smaller alpha payload.
 - [x] [B317] Resolved alpha MOV size by scaling ProRes quantization with frame size and using 8-bit alpha, plus ffmpeg capability checks.
+- [ ] [I109] Use non-alpha encoding when a background image or solid color is provided; reserve alpha output for transparent backgrounds.
+- [x] [I109] Resolved opaque output by switching to H.264 (libx264) when alpha is not needed and validating the codec in integration tests.

--- a/render_text_video.py
+++ b/render_text_video.py
@@ -1406,6 +1406,11 @@ def parse_args(argv: Sequence[str]) -> RenderRequest:
         height = parsed.height
 
     alpha_mode = select_alpha_mode(background_rgba, background_image)
+    if alpha_mode == VideoAlphaMode.OPAQUE and (width % 2 or height % 2):
+        raise RenderValidationError(
+            INVALID_CONFIG_CODE,
+            "width and height must be even for opaque output",
+        )
     min_font_size, max_font_size = compute_font_size_range(width, height)
     if parsed.font_min is not None and parsed.font_max is not None:
         min_font_size = parsed.font_min

--- a/render_text_video.py
+++ b/render_text_video.py
@@ -375,7 +375,7 @@ def render_letter_image(
     letter_image = Image.new("RGBA", (letter_width, letter_height), (0, 0, 0, 0))
     letter_draw = ImageDraw.Draw(letter_image)
     letter_draw.text(
-        (-left, -top), character, font=font, fill=color_rgba, anchor="lb"
+        (-left, -top), character, font=font, fill=color_rgba, anchor="ls"
     )
     return letter_image
 
@@ -390,7 +390,7 @@ def build_letter_layout(
     letters: list[LetterToken] = []
     for character in word_text:
         letter_bbox = draw_context.textbbox(
-            (0, 0), character, font=font, stroke_width=0, anchor="lb"
+            (0, 0), character, font=font, stroke_width=0, anchor="ls"
         )
         letter_image = render_letter_image(
             character, font, color_rgba, letter_bbox

--- a/render_text_video.py
+++ b/render_text_video.py
@@ -1379,10 +1379,15 @@ def parse_args(argv: Sequence[str]) -> RenderRequest:
 
     alpha_mode = select_alpha_mode(background_rgba, background_image)
     min_font_size, max_font_size = compute_font_size_range(width, height)
-    if parsed.font_min is not None:
+    if parsed.font_min is not None and parsed.font_max is not None:
         min_font_size = parsed.font_min
-    if parsed.font_max is not None:
         max_font_size = parsed.font_max
+    elif parsed.font_min is not None:
+        min_font_size = parsed.font_min
+        max_font_size = max(max_font_size, min_font_size)
+    elif parsed.font_max is not None:
+        max_font_size = parsed.font_max
+        min_font_size = min(min_font_size, max_font_size)
     if min_font_size > max_font_size:
         raise RenderValidationError(
             INVALID_CONFIG_CODE, "font-min exceeds font-max"

--- a/tests/test_render_text_video.py
+++ b/tests/test_render_text_video.py
@@ -1107,6 +1107,42 @@ def test_font_bounds_apply_for_criss_cross(tmp_path: Path) -> None:
     assert all(40 <= size <= 50 for size in sizes)
 
 
+def test_font_max_clamps_default_min(tmp_path: Path) -> None:
+    """Clamp the default minimum when only font-max is provided."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "render_text_video.py"
+    fonts_dir = get_test_fonts_dir(repo_root)
+
+    input_text = "alpha beta gamma"
+    input_path = tmp_path / "words.txt"
+    input_path.write_text(input_text, encoding="utf-8")
+
+    output_path = tmp_path / "out.mov"
+    args = build_common_args(
+        script_path=script_path,
+        input_path=input_path,
+        output_path=output_path,
+        fonts_dir=fonts_dir,
+        duration_seconds="0.9",
+        fps="6",
+    )
+    args.extend(
+        [
+            "--subtitle-renderer",
+            "criss_cross",
+            "--font-max",
+            "20",
+            "--emit-directions",
+        ]
+    )
+    result = run_render_text_video(args, repo_root)
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    sizes = payload["font_sizes"]
+    assert sizes
+    assert all(size == 20 for size in sizes)
+
+
 def test_font_bounds_invalid_range_fails(tmp_path: Path) -> None:
     """Reject invalid font bounds where min exceeds max."""
     repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_render_text_video.py
+++ b/tests/test_render_text_video.py
@@ -1419,6 +1419,62 @@ def test_background_image_conflicts_with_dimensions(tmp_path: Path) -> None:
     assert "render_text_video.input.invalid_config" in result.stderr
 
 
+def test_opaque_requires_even_dimensions(tmp_path: Path) -> None:
+    """Fail when opaque output is requested with odd dimensions."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "render_text_video.py"
+    fonts_dir = get_test_fonts_dir(repo_root)
+
+    input_text = "alpha"
+    input_path = tmp_path / "words.txt"
+    input_path.write_text(input_text, encoding="utf-8")
+
+    output_path = tmp_path / "out.mov"
+    args = build_common_args(
+        script_path=script_path,
+        input_path=input_path,
+        output_path=output_path,
+        fonts_dir=fonts_dir,
+        duration_seconds="0.6",
+        fps="6",
+        width=101,
+        height=100,
+    )
+    args.extend(["--background", "#000000"])
+    result = run_render_text_video(args, repo_root)
+    assert result.returncode != 0
+    assert "render_text_video.input.invalid_config" in result.stderr
+
+
+def test_background_image_requires_even_dimensions(tmp_path: Path) -> None:
+    """Fail when background image dimensions are odd for opaque output."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "render_text_video.py"
+    fonts_dir = get_test_fonts_dir(repo_root)
+
+    input_text = "alpha beta"
+    input_path = tmp_path / "words.txt"
+    input_path.write_text(input_text, encoding="utf-8")
+
+    background_path = tmp_path / "background.png"
+    write_png(background_path, 11, 12, (0, 0, 0, 255))
+
+    output_path = tmp_path / "out.mov"
+    args = build_common_args(
+        script_path=script_path,
+        input_path=input_path,
+        output_path=output_path,
+        fonts_dir=fonts_dir,
+        duration_seconds="1.0",
+        fps="6",
+        include_dimensions=False,
+    )
+    args.extend(["--background-image", str(background_path)])
+    result = run_render_text_video(args, repo_root)
+    assert result.returncode != 0
+    assert "render_text_video.input.invalid_config" in result.stderr
+
+
 def test_requires_dimensions_without_background(tmp_path: Path) -> None:
     """Fail when no dimensions or background image are provided."""
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary\n- scale ProRes qscale by frame size and use 8-bit alpha to reduce output size\n- validate ffmpeg encoder/pixel format support for alpha_bits\n- update docs for ffmpeg requirements\n\n## Testing\n- make lint\n- make test\n- make ci